### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     ignore:
       - dependency-name: "com.google.protobuf:protoc"
         versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     directory: "/server"
     commit-message:
@@ -24,3 +26,5 @@ updates:
     ignore:
       - dependency-name: "com.google.protobuf:protoc"
         versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Delays Dependabot version updates by 7 days after a new release is
published. This reduces exposure to supply-chain attacks (malicious
or compromised packages are typically caught and pulled within days
of publication) and supports SOC 2 change-management controls around
vetted, non-immediate dependency updates.

Adds a `cooldown: default-days: 7` block to each `updates` entry in
`.github/dependabot.yml`. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/reducing-the-number-of-pull-requests-dependabot-opens#configuring-cooldown-options
